### PR TITLE
alternative to fixed paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,12 @@
 cmake_minimum_required (VERSION 3.0)
 project (drtaint)
 
-set(DynamoRIO_DIR         /home/piazzt/SD/Build/dynamorio/exports/cmake)
+IF(!DynamoRIO_DIR)
+  set(DynamoRIO_DIR         /home/piazzt/SD/Build/dynamorio/exports/cmake)
+ENDIF()
+IF(!DrMemoryFramework_DIR)
 set(DrMemoryFramework_DIR /home/piazzt/install/exports32/drmf)
+ENDIF()
 
 set(CMAKE_CXX_STANDARD 11)
 add_library(draslrharden SHARED

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+all:
+	mkdir -p build
+	cd build && cmake .. -DDynamoRIO_DIR="$(DYNAMORIO_HOME)/cmake" -DDrMemoryFramework="$(DRMEMORY_HOME)" && make
+
+install: all
+	install -d /usr/local/lib/dynamorio
+	install build/lib*.so /usr/local/lib/dynamorio
+	#install drtaint.sh /usr/local/bin/
+
+clean:
+	rm -rf build


### PR DESCRIPTION
small fix to provide an alternative to the hardcoded paths.

small question - on ARM32/AARCHXX dynamorio forever loops for me when I insert instrumentations around OP_strex. did you notice the same issue in drtaint? (this is not a bug I encountered in drtaint but in my own experiments)

